### PR TITLE
joyent/triton-cmon#21 Install doc prometheus example should be __param_datacenter_name

### DIFF
--- a/docs/INSTALLING.md
+++ b/docs/INSTALLING.md
@@ -324,8 +324,8 @@ instances.
       relabel_configs:
         - source_labels: [__meta_triton_machine_alias]
           target_label: instance
-        - source_labels: [__param_data center_name]
-          target_label: data center_name
+        - source_labels: [__param_datacenter_name]
+          target_label: datacenter_name
           replacement: eg-1
         - source_labels: [__param_account]
           target_label: account_name


### PR DESCRIPTION
- Just a small fix. Noticed while testing.