### PR TITLE
TRITON-2123 cmon should omit nat zones

### DIFF
--- a/lib/common.js
+++ b/lib/common.js
@@ -260,7 +260,11 @@ function mapVm(vm, source, cb) {
          */
         var has_core_tag = false;
         if (vm.tags['smartdc_role'] || vm.tags['manta_role']) {
-            has_core_tag = true;
+            if (vm.tags['smartdc_role'] && vm.tags['smartdc_role'] === 'nat') {
+                err = new Error('do not cache nat zone');
+            } else {
+                has_core_tag = true;
+            }
         }
         /*
          * record manta_role, if any, which will be joined with

--- a/lib/updater.js
+++ b/lib/updater.js
@@ -3,7 +3,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  *
- * Copyright (c) 2019, Joyent, Inc.
+ * Copyright 2020 Joyent, Inc.
  */
 
 // jsl:ignore
@@ -56,7 +56,7 @@ function _mapAndCacheVm(vm, source, cache, log, cb) {
          */
         if (mErr) {
             log.warn({ err: mErr, skippedVm: vm},
-                'Skipping incomplete vm object');
+                'Skipping vm object');
             cb();
             return;
         } else {


### PR DESCRIPTION
For reference, CNS doesn't provide names for nat zones, so CMON can't work on them.

https://github.com/joyent/triton-cns/commit/dca1dc665817af22e764649907678887761fb1de