### PR TITLE
TRITON-2124 Want cmon to expose CN hostnames in discovery

### DIFF
--- a/lib/endpoints/discover.js
+++ b/lib/endpoints/discover.js
@@ -27,9 +27,11 @@ function apiGetCNs(req, res, next) {
 
     var payload = { cns: [] };
     mod_vasync.forEachPipeline({
-        'inputs': Array.from(cache.admin_ips.keys()),
+        'inputs': Array.from(cache.admin_ips),
         'func': function _processCnObj(cnObj, nextCnObj) {
-            var cn = { server_uuid: cnObj };
+            var server_uuid = cnObj[0];
+            var cn_hostname = cnObj[1].cn_hostname;
+            var cn = { server_uuid: server_uuid, server_hostname: cn_hostname };
             payload.cns.push(cn);
             nextCnObj();
         }}, function _processCnObjError(fepErr) {

--- a/lib/updater.js
+++ b/lib/updater.js
@@ -251,7 +251,7 @@ function cacheCn(opts, cb) {
     mod_assert.object(opts.log, 'opts.log');
     mod_assert.uuid(opts.server_uuid, 'opts.server_uuid');
 
-    var admin_ip;
+    var admin_ip, cn_hostname;
     var cache = opts.cache;
     var cn = opts.cn;
     var log = opts.log;
@@ -264,13 +264,16 @@ function cacheCn(opts, cb) {
      * used to get the admin IP for a CN.
      */
     admin_ip = mod_netconfig.agentIpFromSysinfo(cn.sysinfo);
+    cn_hostname = cn.sysinfo.Hostname;
     if (!admin_ip) {
         throw new lib_errors.CMONError('No admin NICs found.');
     }
 
-    cache.admin_ips.set(server_uuid, { admin_ip: admin_ip });
+    cache.admin_ips.set(server_uuid, { admin_ip: admin_ip,
+        cn_hostname: cn_hostname });
 
-    log.debug({server_uuid: server_uuid, admin_ip: admin_ip}, 'Cached CN');
+    log.debug({server_uuid: server_uuid, admin_ip: admin_ip,
+        cn_hostname: cn_hostname}, 'Cached CN');
 
     cb();
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "triton-cmon",
   "description": "Triton Container Monitor",
-  "version": "1.6.2",
+  "version": "1.7.0",
   "author": "Joyent (joyent.com)",
   "repository": {
     "type": "git",


### PR DESCRIPTION
This works for me, but I have no idea if this will work for mock cloud, or even how to test it.

```
$ cmon -i -p coal -g discover | json -H
{
  "cns": [
    {
      "server_uuid": "3d4217aa-9985-4fcd-82df-102eda3fff0e",
      "server_hostname": "headnode"
    },
    {
      "server_uuid": "deec4f3b-38e8-463e-8d6d-d08e3d86e427",
      "server_hostname": "cn1"
    },
    {
      "server_uuid": "55db0aec-9916-4087-9b37-c922a2cb33f1",
      "server_hostname": "cn2"
    },
    {
      "server_uuid": "53f9b8c0-a32e-4569-b901-164fc1ae448b",
      "server_hostname": "cn3"
    }
  ]
}
```