### PR TITLE
TRITON-2207 Update services to fix node-artedi#16 label values not escaped properly

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "triton-cmon",
   "description": "Triton Container Monitor",
-  "version": "1.8.0",
+  "version": "1.8.1",
   "author": "Joyent (joyent.com)",
   "repository": {
     "type": "git",
@@ -21,7 +21,7 @@
     "sdc-scripts": "git+https://github.com/joyent/sdc-scripts.git#deefaef587ed3bee2706cb6e53ee3468e682932e",
     "sshpk": "1.14.2",
     "tape": "4.2.2",
-    "triton-metrics": "0.2.0",
+    "triton-metrics": "1.0.3",
     "triton-netconfig": "1.3.0",
     "triton-tags": "1.3.0",
     "vasync": "1.6.4",


### PR DESCRIPTION
This is a public facing service that needs to be updated.