### PR TITLE
joyent/triton-cmon#27 want support for "administrator" role

### DIFF
--- a/lib/common.js
+++ b/lib/common.js
@@ -86,9 +86,37 @@ function authenticationHandler(req, res, next) {
             if (err) {
                 req.log.error({ mahiAcctErr: err }, 'Error getting acct');
                 next(new lib_errors.UnauthorizedError());
-            } else if (!acct.account.keys[keyId]) {
-                req.log.error({ keyId: keyId }, 'Key not present on account');
-                next(new lib_errors.UnauthorizedError());
+
+            } else if (!acct.account.keys || acct.account.keys[keyId]) {
+                var path = '/roles?account=' + cn + '&role=administrator';
+                req.app.mahi._get(path, function (err, info) {
+                    if (err || info.role === undefined) {
+                        req.log.error({ keyId: keyId },
+                            'Key not present on account');
+                        next(new lib_errors.UnauthorizedError());
+                        return;
+                    }
+                    var found = false;
+                    for (var uuid in info.role.members) {
+                        var keys = info.role.members[uuid].keys;
+                        if (keys && keys[keyId]) {
+                            var key = mod_sshpk.parseKey(keys[keyId]);
+                            if (cert.isSignedByKey(key)) {
+                                found = true;
+                                break;
+                            }
+                        }
+                    }
+                    if (found) {
+                        req.account = acct.account;
+                        next();
+                    } else {
+                        req.log.error({ keyId: keyId },
+                            'Key not present on account');
+                        next(new lib_errors.UnauthorizedError());
+                    }
+                });
+
             } else {
                 var key = mod_sshpk.parseKey(acct.account.keys[keyId]);
                 /*


### PR DESCRIPTION
This has been running in production at UQ for the last few months. It requires a change in mahi (https://github.com/joyent/mahi/pull/15) in order to function, but will fall back to the old behaviour (no support for administrator role, but regular auth with a key on the account still works) if mahi is not up-to-date.

As with the change in sdc-docker, generating certificates to use with this feature requires a change in node-triton to support the `--act-as` switch with `triton profile cmon-certgen`. The patch is at https://github.com/eait-itig/node-triton/commit/e2b9d39ade282d54cbb298bd82d278670dfad869 for testing but will be cleaned up and PR'd separately once the docker and CMON server-side changes are in.