### PR TITLE
triton-cmon#37 Want stopped instances to be discoverable

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -239,7 +239,7 @@ file.
 | server_opts                      | Object    | -          | CMON server options.                                                    |
 | server_opts.http_accept_encoding | String    | -          | When set to "enabled" CMON honors 'Accept-Encoding'                     |
 | throttle_opts                    | Object    | -          | Restify [throttle](http://restify.com/docs/plugins-api/#throttle) opts. |
-| discover_include_stopped         | String    | false      | Whether to include stopped instances in addition to running instances.  |
+| discoverIncludeStopped           | String    | false      | Whether to include stopped instances in addition to running instances.  |
 
 
 
@@ -257,4 +257,4 @@ production.
 | key                            | type    | default   | description                                          |
 | ------------------------------ | ------- | --------- | ---------------------------------------------------- |
 | HTTP_ACCEPT_ENCODING           | String  | ""        | Sets `server_opts.http_accept_encoding` above.       |
-| discover_include_stopped       | String  | false     | Sets `discover_include_stopped` above.               |
+| discover_include_stopped       | String  | false     | Sets `discoverIncludeStopped` above.                 |

--- a/docs/README.md
+++ b/docs/README.md
@@ -239,6 +239,7 @@ file.
 | server_opts                      | Object    | -          | CMON server options.                                                    |
 | server_opts.http_accept_encoding | String    | -          | When set to "enabled" CMON honors 'Accept-Encoding'                     |
 | throttle_opts                    | Object    | -          | Restify [throttle](http://restify.com/docs/plugins-api/#throttle) opts. |
+| discover_include                 | String    | running    | Set to 'active' to include all active instances. Default is 'running'. Invalid values are ignored. |
 
 
 
@@ -253,6 +254,7 @@ In the SAPI "cmon" service, adding or changing the following keys in
 `metadata` can change some VMAPI behaviours for specialized circumstances in
 production.
 
-| key                            | type   | default   | description                                          |
-| ------------------------------ | ------ | --------- | ---------------------------------------------------- |
-| HTTP_ACCEPT_ENCODING           | String | ""        | Sets `server_opts.http_accept_encoding` above.       |
+| key                            | type    | default   | description                                          |
+| ------------------------------ | ------- | --------- | ---------------------------------------------------- |
+| HTTP_ACCEPT_ENCODING           | String  | ""        | Sets `server_opts.http_accept_encoding` above.       |
+| discover_include               | String  | running   | Sets `discover_include` above.                       |

--- a/docs/README.md
+++ b/docs/README.md
@@ -239,7 +239,7 @@ file.
 | server_opts                      | Object    | -          | CMON server options.                                                    |
 | server_opts.http_accept_encoding | String    | -          | When set to "enabled" CMON honors 'Accept-Encoding'                     |
 | throttle_opts                    | Object    | -          | Restify [throttle](http://restify.com/docs/plugins-api/#throttle) opts. |
-| discover_include_stopped         | String    | false      | Set to 'true' to include stopped instances in addition to running instances. |
+| discover_include_stopped         | String    | false      | Whether to include stopped instances in addition to running instances.  |
 
 
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -239,7 +239,7 @@ file.
 | server_opts                      | Object    | -          | CMON server options.                                                    |
 | server_opts.http_accept_encoding | String    | -          | When set to "enabled" CMON honors 'Accept-Encoding'                     |
 | throttle_opts                    | Object    | -          | Restify [throttle](http://restify.com/docs/plugins-api/#throttle) opts. |
-| discover_include                 | String    | running    | Set to 'active' to include all active instances. Default is 'running'. Invalid values are ignored. |
+| discover_include_stopped         | String    | false      | Set to 'true' to include stopped instances in addition to running instances. |
 
 
 
@@ -257,4 +257,4 @@ production.
 | key                            | type    | default   | description                                          |
 | ------------------------------ | ------- | --------- | ---------------------------------------------------- |
 | HTTP_ACCEPT_ENCODING           | String  | ""        | Sets `server_opts.http_accept_encoding` above.       |
-| discover_include               | String  | running   | Sets `discover_include` above.                       |
+| discover_include_stopped       | String  | false     | Sets `discover_include_stopped` above.               |

--- a/lib/app.js
+++ b/lib/app.js
@@ -319,7 +319,7 @@ function _fetchVm(log, vmapi, arg, lobj, datacb, cb) {
     mod_assert.optionalFunc(datacb, 'datacb');
 
     var done = false;
-    var vmapiFilter = { limit: lobj.limit, state: 'running' };
+    var vmapiFilter = { limit: lobj.limit, state: 'active' };
     if (lobj.marker) {
         vmapiFilter.marker = lobj.marker;
     }

--- a/lib/app.js
+++ b/lib/app.js
@@ -325,7 +325,7 @@ function _fetchVm(log, vmapi, config, arg, lobj, datacb, cb) {
     };
 
     // optionally include stopped instances
-    if (config.discover_include_stopped === 'true') {
+    if (config.discoverIncludeStopped === 'true') {
         vmapiFilter.predicate = JSON.stringify({
             or: [
                 { eq: ['state', 'running'] },

--- a/lib/app.js
+++ b/lib/app.js
@@ -321,9 +321,20 @@ function _fetchVm(log, vmapi, config, arg, lobj, datacb, cb) {
     var done = false;
 
     var vmapiFilter = {
-        limit: lobj.limit,
-        state: (config.discover_include === 'active' ? 'active' : 'running')
+        limit: lobj.limit
     };
+
+    // optionally include stopped instances
+    if (config.discover_include_stopped === 'true') {
+        vmapiFilter.predicate = JSON.stringify({
+            or: [
+                { eq: ['state', 'running'] },
+                { eq: ['state', 'stopped'] }
+            ]
+        });
+    } else {
+        vmapiFilter.state = 'running';
+    }
 
     if (lobj.marker) {
         vmapiFilter.marker = lobj.marker;

--- a/lib/app.js
+++ b/lib/app.js
@@ -5,7 +5,7 @@
  */
 
 /*
- * Copyright 2020 Joyent, Inc.
+ * Copyright 2022 Joyent, Inc.
  */
 
 // jsl:ignore
@@ -321,7 +321,7 @@ function _fetchVm(log, vmapi, config, arg, lobj, datacb, cb) {
     var done = false;
 
     var vmapiFilter = {
-        limit: lobj.limit, 
+        limit: lobj.limit,
         state: (config.scrape_down_instances === true ? 'active' : 'running')
     };
 

--- a/lib/app.js
+++ b/lib/app.js
@@ -104,7 +104,7 @@ function App(opts) {
     }
 
     function _callFetchVm(arg, lobj, datacb, cb) {
-        _fetchVm(self.log, self.vmapi, arg, lobj, datacb, cb);
+        _fetchVm(self.log, self.vmapi, self.config, arg, lobj, datacb, cb);
     }
 
     /*
@@ -314,12 +314,17 @@ function _fetchCn(log, cnapi, arg, lobj, datacb, cb) {
     });
 }
 
-function _fetchVm(log, vmapi, arg, lobj, datacb, cb) {
+function _fetchVm(log, vmapi, config, arg, lobj, datacb, cb) {
     mod_assert.optionalObject(arg, 'arg');
     mod_assert.optionalFunc(datacb, 'datacb');
 
     var done = false;
-    var vmapiFilter = { limit: lobj.limit, state: 'active' };
+
+    var vmapiFilter = {
+        limit: lobj.limit, 
+        state: (config.scrape_down_instances === true ? 'active' : 'running')
+    };
+
     if (lobj.marker) {
         vmapiFilter.marker = lobj.marker;
     }

--- a/lib/app.js
+++ b/lib/app.js
@@ -322,7 +322,7 @@ function _fetchVm(log, vmapi, config, arg, lobj, datacb, cb) {
 
     var vmapiFilter = {
         limit: lobj.limit,
-        state: (config.scrape_down_instances === true ? 'active' : 'running')
+        state: (config.discover_include === 'active' ? 'active' : 'running')
     };
 
     if (lobj.marker) {

--- a/lib/common.js
+++ b/lib/common.js
@@ -5,7 +5,7 @@
  */
 
 /*
- * Copyright 2021 Joyent, Inc.
+ * Copyright 2022 Joyent, Inc.
  */
 
 // jsl:ignore

--- a/lib/common.js
+++ b/lib/common.js
@@ -271,8 +271,6 @@ function mapVm(vm, source, cb) {
         err = new Error('vm.uuid must be a string');
     } else if (!(typeof (vm.state) === 'string')) {
         err = new Error('vm.state must be a string');
-    } else if (!(typeof (vm.tags) === 'object')) {
-        err = new Error('vm.tags must be a object');
     } else {
         var cmon_groups_str = vm.tags['triton.cmon.groups'];
         var cmon_groups = [];
@@ -307,12 +305,6 @@ function mapVm(vm, source, cb) {
             manta_role = vm.tags['manta_role'];
         }
 
-        // Need to Convert all values in object to string before mapping
-        for (var tag in vm.tags) {
-            var stringTag = vm.tags[tag].toString();
-            vm.tags[tag] = stringTag;
-        }
-
         mappedVm =
         {
             groups: cmon_groups,
@@ -325,8 +317,7 @@ function mapVm(vm, source, cb) {
             vm_image_uuid: vm.image_uuid,
             vm_owner_uuid: vm.owner_uuid,
             vm_uuid: vm.uuid,
-            vm_state: vm.state,
-            vm_tags: vm.tags
+            vm_state: vm.state
         };
     }
 

--- a/lib/common.js
+++ b/lib/common.js
@@ -269,6 +269,10 @@ function mapVm(vm, source, cb) {
         err = new Error('vm.owner_uuid must be a string');
     } else if (!(typeof (vm.uuid) === 'string')) {
         err = new Error('vm.uuid must be a string');
+    } else if (!(typeof (vm.state) === 'string')) {
+        err = new Error('vm.state must be a string');
+    } else if (!(typeof (vm.tags) === 'object')) {
+        err = new Error('vm.tags must be a object');
     } else {
         var cmon_groups_str = vm.tags['triton.cmon.groups'];
         var cmon_groups = [];
@@ -303,6 +307,12 @@ function mapVm(vm, source, cb) {
             manta_role = vm.tags['manta_role'];
         }
 
+        // Need to Convert all values in object to string before mapping
+        for (var tag in vm.tags) {
+            var stringTag = vm.tags[tag].toString();
+            vm.tags[tag] = stringTag;
+        }
+
         mappedVm =
         {
             groups: cmon_groups,
@@ -314,7 +324,9 @@ function mapVm(vm, source, cb) {
             vm_brand: vm.brand,
             vm_image_uuid: vm.image_uuid,
             vm_owner_uuid: vm.owner_uuid,
-            vm_uuid: vm.uuid
+            vm_uuid: vm.uuid,
+            vm_state: vm.state,
+            vm_tags: vm.tags
         };
     }
 

--- a/lib/endpoints/discover.js
+++ b/lib/endpoints/discover.js
@@ -95,11 +95,11 @@ function apiGetContainers(req, res, next) {
 
                 var containers = Array.from(accountVms.values());
 
-                // filter out VMs that have the 'triton.cmon.disable' tag set to true
-                containers = containers.filter(
-                    function cmonEnabled(container) {
-                        return !(container.vm_tags && container.vm_tags['_triton.cmon.disable'] === 'true');
-                    });
+                // filter out VMs with the _triton.cmon.disable=true tag
+                containers = containers.filter(function cmonEnabled(container) {
+                    return !(container.vm_tags && 
+                        container.vm_tags['_triton.cmon.disable'] === 'true');
+                });
 
                 /*
                  * If a group tag filter was specified then we remove containers

--- a/lib/endpoints/discover.js
+++ b/lib/endpoints/discover.js
@@ -95,6 +95,12 @@ function apiGetContainers(req, res, next) {
 
                 var containers = Array.from(accountVms.values());
 
+                // filter out VMs that have the 'triton.cmon.disable' tag set to true
+                containers = containers.filter(
+                    function cmonEnabled(container) {
+                        return !(container.vm_tags && container.vm_tags['_triton.cmon.disable'] === 'true');
+                    });
+
                 /*
                  * If a group tag filter was specified then we remove containers
                  * from the payload that do not match the specified tag(s).

--- a/lib/endpoints/discover.js
+++ b/lib/endpoints/discover.js
@@ -5,7 +5,7 @@
  */
 
 /*
- * Copyright 2020 Joyent, Inc.
+ * Copyright 2022 Joyent, Inc.
  */
 
 // jsl:ignore
@@ -97,7 +97,7 @@ function apiGetContainers(req, res, next) {
 
                 // filter out VMs with the _triton.cmon.disable=true tag
                 containers = containers.filter(function cmonEnabled(container) {
-                    return !(container.vm_tags && 
+                    return !(container.vm_tags &&
                         container.vm_tags['_triton.cmon.disable'] === 'true');
                 });
 

--- a/lib/endpoints/discover.js
+++ b/lib/endpoints/discover.js
@@ -95,12 +95,6 @@ function apiGetContainers(req, res, next) {
 
                 var containers = Array.from(accountVms.values());
 
-                // filter out VMs with the _triton.cmon.disable=true tag
-                containers = containers.filter(function cmonEnabled(container) {
-                    return !(container.vm_tags &&
-                        container.vm_tags['_triton.cmon.disable'] === 'true');
-                });
-
                 /*
                  * If a group tag filter was specified then we remove containers
                  * from the payload that do not match the specified tag(s).

--- a/lib/endpoints/metrics.js
+++ b/lib/endpoints/metrics.js
@@ -133,7 +133,8 @@ function apiGetMetrics(req, res, next) {
          * for alert rules to detect containers that are not running.
          */
         if (vmCacheItem.vm_state !== 'running') {
-            req.log.info({ vm: vmCacheItem }, 'Not calling cmon-agent because VM is not running');
+            req.log.info({ vm: vmCacheItem }, 
+                'Not calling cmon-agent because VM is not running');
             next(new lib_errors.NotFoundError());
             return;
         }

--- a/lib/endpoints/metrics.js
+++ b/lib/endpoints/metrics.js
@@ -126,6 +126,18 @@ function apiGetMetrics(req, res, next) {
         admin_ip = serverCacheItem.admin_ip;
         mod_assert.string(admin_ip, 'admin_ip');
 
+        /* 
+         * Avoid calling cmon-agent for VMs that are not running since that 
+         * will return an error anyway. Return a non-200 response code so that 
+         * prometheus will set its built-in "up" metric to "0" which allows 
+         * for alert rules to detect containers that are not running.
+         */
+        if (vmCacheItem.vm_state !== 'running') {
+            req.log.info({ vm: vmCacheItem }, 'Not calling cmon-agent because VM is not running');
+            next(new lib_errors.NotFoundError());
+            return;
+        }
+
         var headerObj = {
             isCoreZone: vmCacheItem.has_core_tag && req.account.isOperator
         };

--- a/lib/endpoints/metrics.js
+++ b/lib/endpoints/metrics.js
@@ -133,7 +133,7 @@ function apiGetMetrics(req, res, next) {
          * for alert rules to detect containers that are not running.
          */
         if (vmCacheItem.vm_state !== 'running') {
-            req.log.info({ vm: vmCacheItem },
+            req.log.debug({ vm: vmCacheItem },
                 'Not calling cmon-agent because VM is not running');
             next(new lib_errors.NotFoundError());
             return;

--- a/lib/endpoints/metrics.js
+++ b/lib/endpoints/metrics.js
@@ -5,7 +5,7 @@
  */
 
 /*
- * Copyright 2020 Joyent, Inc.
+ * Copyright 2022 Joyent, Inc.
  */
 
 // jsl:ignore
@@ -126,14 +126,14 @@ function apiGetMetrics(req, res, next) {
         admin_ip = serverCacheItem.admin_ip;
         mod_assert.string(admin_ip, 'admin_ip');
 
-        /* 
-         * Avoid calling cmon-agent for VMs that are not running since that 
-         * will return an error anyway. Return a non-200 response code so that 
-         * prometheus will set its built-in "up" metric to "0" which allows 
+        /*
+         * Avoid calling cmon-agent for VMs that are not running since that
+         * will return an error anyway. Return a non-200 response code so that
+         * prometheus will set its built-in "up" metric to "0" which allows
          * for alert rules to detect containers that are not running.
          */
         if (vmCacheItem.vm_state !== 'running') {
-            req.log.info({ vm: vmCacheItem }, 
+            req.log.info({ vm: vmCacheItem },
                 'Not calling cmon-agent because VM is not running');
             next(new lib_errors.NotFoundError());
             return;

--- a/lib/updater.js
+++ b/lib/updater.js
@@ -106,7 +106,7 @@ function _handleCfChunk(cf_chunk, cf_arg, cf_cb) {
          * with the given VM.
          */
         cf_arg.server = { server_uuid: vm.server_uuid };
-        if (vm.state !== 'destroyed') {
+        if (vm.state === 'running' || vm.state === 'stopped') {
             _mapAndCacheVm(vm, 'Changefeed', cache, log, cf_cb);
             return;
         } else if (vm.state === 'destroyed') {

--- a/lib/updater.js
+++ b/lib/updater.js
@@ -36,7 +36,7 @@ function Updater(opts) {
     this.vmapi = opts.app.vmapi;
     this.cnapi = opts.app.cnapi;
     this.cache = opts.app.cache;
-
+    this.config = opts.app.config;
 }
 mod_util.inherits(Updater, mod_stream.Writable);
 
@@ -94,6 +94,8 @@ function _handleCfChunk(cf_chunk, cf_arg, cf_cb) {
     var vmapi = self.vmapi;
     var cache = self.cache;
     var log = self.log;
+    var config = self.config;
+
     var vmapiFilter = { uuid: cf_chunk.changedResourceId };
     vmapi.listVms(vmapiFilter, function _handleVms(vmErr, vms) {
         mod_assert.ifError(vmErr, 'Error fetching VM');
@@ -106,10 +108,28 @@ function _handleCfChunk(cf_chunk, cf_arg, cf_cb) {
          * with the given VM.
          */
         cf_arg.server = { server_uuid: vm.server_uuid };
-        if (vm.state === 'running' || vm.state === 'stopped') {
+
+        var cacheVm = false;
+        var removeVMFromCache = false;
+
+        if (config.discoverIncludeStopped === 'true') {
+            if (vm.state === 'running' || vm.state === 'stopped') {
+                cacheVm = true;
+            } else if (vm.state === 'destroyed') {
+                removeVMFromCache = true;
+            }
+        } else {
+            if (vm.state === 'running') {
+                cacheVm = true;
+            } else if (vm.state === 'stopped' || vm.state === 'destroyed') {
+                removeVMFromCache = true;
+            }
+        }
+
+        if (cacheVm) {
             _mapAndCacheVm(vm, 'Changefeed', cache, log, cf_cb);
             return;
-        } else if (vm.state === 'destroyed') {
+        } else if (removeVMFromCache) {
             if (cache.vms.has(vm.uuid)) {
                 cache.vms.delete(vm.uuid);
                 log.trace(

--- a/lib/updater.js
+++ b/lib/updater.js
@@ -3,7 +3,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  *
- * Copyright 2020 Joyent, Inc.
+ * Copyright 2022 Joyent, Inc.
  */
 
 // jsl:ignore

--- a/lib/updater.js
+++ b/lib/updater.js
@@ -106,10 +106,10 @@ function _handleCfChunk(cf_chunk, cf_arg, cf_cb) {
          * with the given VM.
          */
         cf_arg.server = { server_uuid: vm.server_uuid };
-        if (vm.state === 'running') {
+        if (vm.state !== 'destroyed') {
             _mapAndCacheVm(vm, 'Changefeed', cache, log, cf_cb);
             return;
-        } else if (vm.state === 'stopped' || vm.state === 'destroyed') {
+        } else if (vm.state === 'destroyed') {
             if (cache.vms.has(vm.uuid)) {
                 cache.vms.delete(vm.uuid);
                 log.trace(

--- a/sapi_manifests/cmon/template
+++ b/sapi_manifests/cmon/template
@@ -8,6 +8,12 @@
     "port": 9163,
     "serviceName": "{{SERVICE_NAME}}",
     "serverUuid": "{{auto.SERVER_UUID}}",
+    {{^CMON_SCRAPE_DOWN_INSTANCES}}
+    "scrape_down_instances": false,
+    {{/CMON_SCRAPE_DOWN_INSTANCES}}
+    {{#CMON_SCRAPE_DOWN_INSTANCES}}
+    "scrape_down_instances": true,
+    {{/CMON_SCRAPE_DOWN_INSTANCES}}
     "vmapi": {
         "url": "http://{{{vmapi_domain}}}"
     },

--- a/sapi_manifests/cmon/template
+++ b/sapi_manifests/cmon/template
@@ -8,12 +8,7 @@
     "port": 9163,
     "serviceName": "{{SERVICE_NAME}}",
     "serverUuid": "{{auto.SERVER_UUID}}",
-    {{^CMON_SCRAPE_DOWN_INSTANCES}}
-    "scrape_down_instances": false,
-    {{/CMON_SCRAPE_DOWN_INSTANCES}}
-    {{#CMON_SCRAPE_DOWN_INSTANCES}}
-    "scrape_down_instances": true,
-    {{/CMON_SCRAPE_DOWN_INSTANCES}}
+    "discover_include": "{{discover_include}}",
     "vmapi": {
         "url": "http://{{{vmapi_domain}}}"
     },

--- a/sapi_manifests/cmon/template
+++ b/sapi_manifests/cmon/template
@@ -8,7 +8,7 @@
     "port": 9163,
     "serviceName": "{{SERVICE_NAME}}",
     "serverUuid": "{{auto.SERVER_UUID}}",
-    "discover_include": "{{discover_include}}",
+    "discover_include_stopped": "{{discover_include_stopped}}",
     "vmapi": {
         "url": "http://{{{vmapi_domain}}}"
     },

--- a/sapi_manifests/cmon/template
+++ b/sapi_manifests/cmon/template
@@ -8,7 +8,7 @@
     "port": 9163,
     "serviceName": "{{SERVICE_NAME}}",
     "serverUuid": "{{auto.SERVER_UUID}}",
-    "discover_include_stopped": "{{discover_include_stopped}}",
+    "discoverIncludeStopped": "{{discover_include_stopped}}",
     "vmapi": {
         "url": "http://{{{vmapi_domain}}}"
     },


### PR DESCRIPTION
The default behavior will remain unchanged but you can opt-in to discover `stopped` instances in addition to `running` instances via a new `discover_include_stopped` SAPI configuration parameter.