### PR TITLE
cmons /data/tls/key.pem should be owned by nobody

### DIFF
--- a/boot/setup.sh
+++ b/boot/setup.sh
@@ -30,6 +30,10 @@ function setup_tls_certificate() {
             -pkeyopt ec_param_enc:named_curve \
             -newkey ec -keyout /data/tls/key.pem \
             -out /data/tls/cert.pem -days 365
+	# Cmon's smf manifest defines "nobody" as the user.
+	# Without this line the svc goes into "maintenance"
+	# on boot.
+	chown nobody:nobody /data/tls/key.pem
         # Remember the certificate's host name used in the cert.
         echo "$HOST" > /data/tls/hostname
     fi


### PR DESCRIPTION
cmons /data/tls/key.pem should be owned by nobody

`sdcadm post-setup cmon` runs successfully but upon completion the cmon smf service goes directly into maintenance state. A bit of cmon log digging and I saw that cmon couldn't load its private key file due to it being owned by root and the cmon service running as "nobody" from smf. 

I just added a line to `setup.sh` to `chown` the 'key.pem' file so that the service can start up properly the first time. 


